### PR TITLE
Fix Attempt to read property "post_type" on null

### DIFF
--- a/network-media-library.php
+++ b/network-media-library.php
@@ -385,7 +385,7 @@ function allow_media_library_access( array $caps, string $cap, int $user_id, arr
 
 	if ( 'edit_post' === $cap ) {
 		$content = get_post( $args[0] );
-		if ( 'attachment' !== $content->post_type ) {
+		if (!isset($content) || 'attachment' !== $content->post_type ) {
 			return $caps;
 		}
 


### PR DESCRIPTION
Fix warning reading property on null (breaks development after syncing production to development)